### PR TITLE
Use of dialog element [Fixes #29]

### DIFF
--- a/app/views/e2/products/new.html.erb
+++ b/app/views/e2/products/new.html.erb
@@ -16,7 +16,7 @@
           </div>
           <div class="flex justify-between items-center mt-3">
             <%= form.submit "Save", disabled: true, class: "px-4 py-1.5 text-white bg-gray-500 rounded-lg" %>
-            <%= link_to "Close", e2_products_path, data: { turbo_frame: "_top" }, class: "hover:opacity-50" %>
+            <button class="px-4 py-1.5 text-red-600 font-semibold rounded-lg hover:opacity-50" value="close" formmethod="dialog">Close</button>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
This changes the `<div  role="dialog">` element to the `<dialog>` element. It also uses the `open` attribute in the `<dialog>` element which is the equivalent of `aria-modal= "true"`.  
The docs on the dialog element are [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).


closes #29 